### PR TITLE
TCM model (with one simplification) and necessary library changes for task-based models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 .classpath
 .project
 .settings
+.DS_Store

--- a/pyclick/click_models/ClickModel.py
+++ b/pyclick/click_models/ClickModel.py
@@ -63,12 +63,6 @@ class ClickModel(object):
         return str(self)
 
     @abstractmethod
-    def predict_click_probs(self, search_session):
-        """Uses the trained parameters to predict click probabilities
-        for results in the given search session."""
-        pass
-
-    @abstractmethod
     def get_session_params(self, search_session):
         """Returns click model parameters that describe the given search session.
         In particular, for each result X in the given search session

--- a/pyclick/click_models/Inference.py
+++ b/pyclick/click_models/Inference.py
@@ -62,5 +62,8 @@ class EMInference(Inference):
                     for param_name, param in new_session_params[rank].items():
                         param.update(search_session, rank, current_session_params)
 
+            for param_container in new_click_model.params.itervalues():
+                param_container.apply_each(lambda param: param.finish_iteration())
+
             #TODO: check memory leaks here
             click_model.params = new_click_model.params

--- a/pyclick/click_models/Param.py
+++ b/pyclick/click_models/Param.py
@@ -4,6 +4,7 @@
 # Full copyright notice can be found in LICENSE.
 #
 from abc import abstractmethod
+from collections import defaultdict
 
 __author__ = 'Ilya Markov'
 
@@ -59,7 +60,7 @@ class ParamMLE(Param):
 class ParamEM(Param):
     """A parameter used in the expectation-maximization inference."""
 
-    PROB_MIN = 0.000001  # probaiblity to use instaed of 0 to protect from the math domain errors
+    PROB_MIN = 0.000001  # probaiblity to use instead of 0 to protect from the math domain errors
 
     def __init__(self):
         self._numerator = 1
@@ -75,6 +76,45 @@ class ParamEM(Param):
         and the values of other parameters.
         """
         pass
+
+    def finish_iteration(self):
+        """Called at the end of EM iteration after update was called for all sessions."""
+        pass
+
+class TaskBasedParamEM(ParamEM):
+    """A parameter that uses sessions in the same task and is trained using EM algorithm."""
+    def __init__(self):
+        self.per_task_sessions = defaultdict(lambda: [])
+        super(TaskBasedParamEM, self).__init__()
+
+    def update(self, search_session, rank, session_params):
+        self.per_task_sessions[search_session.task_id].append(
+                (search_session, rank, session_params))
+
+    @abstractmethod
+    def _update(self, search_session, rank, session_params, history, last_session):
+        """
+        Update internal state using history (previously shown docs) and the last_session flag
+        (set to true if this is the last session in the task).
+        """
+        pass
+
+    def finish_iteration(self):
+        for task_sessions in self.per_task_sessions.itervalues():
+            history = set()
+            for num, (search_session, rank, session_params) in enumerate(task_sessions):
+                last_session = num == len(task_sessions) - 1
+                self._update(search_session, rank, session_params, history, last_session)
+                for d in search_session.web_results:
+                    # TODO(chuklin): in the original paper history is not just the occurence
+                    # of the document, but rather examination of it. Ideally, one should
+                    # sum over position of the first examined occurence: equation (27).
+                    history.add(d.id)
+
+        # Reset the per-task dict
+        self.per_task_sessions.clear()
+
+
 
 
 class ParamStatic(Param):

--- a/pyclick/click_models/ParamContainer.py
+++ b/pyclick/click_models/ParamContainer.py
@@ -64,9 +64,15 @@ class ParamContainer(object):
         """
         pass
 
+    @abstractmethod
+    def each_param(self, func):
+        """Apply func to each param in this container."""
+
 
 class QueryDocumentParamContainer(ParamContainer):
     """A container of click model parameters that depend on a query-document pair."""
+
+    MAX_PARAMS_PRINT = 100
 
     def __init__(self, param_class):
         super(QueryDocumentParamContainer, self).__init__(param_class)
@@ -108,12 +114,21 @@ class QueryDocumentParamContainer(ParamContainer):
 
     def __str__(self):
         param_str = ''
+        counter = 0
         for query in self._container:
+            if self.MAX_PARAMS_PRINT >= 0 and counter > self.MAX_PARAMS_PRINT:
+                break
             param_str += '%s: %r\n' % (query, self._container[query])
+            counter += len(self._container[query])
         return param_str
 
     def __repr__(self):
         return str(self)
+
+    def apply_each(self, func):
+        for d in self._container.itervalues():
+            for param in d.itervalues():
+                func(param)
 
 
 class RankParamContainer(ParamContainer):
@@ -168,6 +183,10 @@ class RankParamContainer(ParamContainer):
 
     def __repr__(self):
         return str(self)
+
+    def apply_each(self, func):
+        for param in self._container:
+            func(param)
 
 
 class RankSquaredParamContainer(ParamContainer):
@@ -234,6 +253,11 @@ class RankSquaredParamContainer(ParamContainer):
     def __repr__(self):
         return str(self)
 
+    def apply_each(self, func):
+        for l in self._container:
+            for param in l:
+                func(param)
+
 
 class SingleParamContainer(ParamContainer):
     """
@@ -262,3 +286,6 @@ class SingleParamContainer(ParamContainer):
 
     def __repr__(self):
         return str(self)
+
+    def apply_each(self, func):
+        func(self._container)

--- a/pyclick/click_models/TCM.py
+++ b/pyclick/click_models/TCM.py
@@ -1,0 +1,200 @@
+#
+# Copyright (C) 2015  Ilya Markov
+#
+# Full copyright notice can be found in LICENSE.
+#
+from enum import Enum
+
+from pyclick.click_models.ClickModel import ClickModel
+from pyclick.click_models.Inference import EMInference
+from pyclick.click_models.Param import ParamEM, TaskBasedParamEM
+from pyclick.click_models.ParamContainer import QueryDocumentParamContainer, RankParamContainer, SingleParamContainer
+
+__author__ = 'Ilya Markov, Aleksandr Chuklin'
+
+
+class TCM(ClickModel):
+    """
+    The task-centric click model.
+    It takes entire search tasks of a user into account. Taken from:
+    Zhang, Yuchen and Chen, Weizhu and Wang, Dong and Yang, Qiang
+    User-click modeling for understanding and predicting search-behavior.
+    2011 in Proceedings of the 17th ACM SIGKDD - KDD '11
+    """
+
+    param_names = Enum('TCMParamNames', 'attr exam match new fresh')
+    """The names of the TCM parameters."""
+
+    def __init__(self):
+        self.params = {self.param_names.attr: QueryDocumentParamContainer(TCMAttrEM),
+                       self.param_names.exam: RankParamContainer.default(TCMExamEM),
+                       self.param_names.match: SingleParamContainer(TCMMatchEM),
+                       self.param_names.new: SingleParamContainer(TCMNewEM),
+                       self.param_names.fresh: SingleParamContainer(TCMFreshEM)}
+        self._inference = EMInference()
+
+    def get_session_params(self, search_session):
+        session_params = []
+
+        fresh = self.params[self.param_names.fresh].get()
+        for rank, result in enumerate(search_session.web_results):
+            attr = self.params[self.param_names.attr].get(search_session.query, result.id)
+            exam = self.params[self.param_names.exam].get(rank)
+
+            param_dict = {self.param_names.attr: attr,
+                          self.param_names.exam: exam,
+                          self.param_names.fresh: fresh}
+            if rank == 0:
+                # Attach the session-wide params to the first document for uniformity.
+                match = self.params[self.param_names.match].get()
+                new = self.params[self.param_names.new].get()
+                param_dict.update({self.param_names.match: match, self.param_names.new: new})
+
+            session_params.append(param_dict)
+
+        return session_params
+
+    def get_conditional_click_probs(self, search_session, result_history):
+        """
+        result_history is a list of boolean values for each document in the session,
+        True corresponds to the cases where the document appeared before for the same task
+        """
+        click_probs = self.predict_click_probs(search_session, result_history)
+
+        for rank, result in enumerate(search_session.web_results):
+            if not result.click:
+                click_probs[rank] = 1 - click_probs[rank]
+
+        return click_probs
+
+    def predict_click_probs(self, search_session, result_history):
+        assert len(search_session.web_results) == len(result_history)
+
+        session_params = self.get_session_params(search_session)
+        click_probs = []
+
+        for rank, session_param in enumerate(session_params):
+            attr = session_param[self.param_names.attr].value()
+            exam = session_param[self.param_names.exam].value()
+
+            click_prob = attr * exam
+            click_probs.append(click_prob)
+
+        return click_probs
+
+    def predict_relevance(self, query, search_result):
+        return self.params[self.param_names.attr].get(query, search_result).value()
+
+
+class TCMAttrEM(TaskBasedParamEM):
+    """
+    The attractiveness parameter of the TCM model.
+    The value of the parameter is inferred using the EM algorithm.
+    """
+    def _update(self, search_session, rank, session_params, history, last_session):
+        doc = search_session.web_results[rank]
+
+        attr = session_params[rank][TCM.param_names.attr].value()
+        exam = session_params[rank][TCM.param_names.exam].value()
+        fresh = session_params[0][TCM.param_names.fresh].value() \
+                if (doc.id in history) else 1.0
+        match = session_params[0][TCM.param_names.match].value()
+
+        if doc.click:
+            self._numerator += 1
+        else:
+            self._numerator += ((1 - exam) * attr * fresh * match /
+                                (1 - exam * attr * fresh * match))
+
+        self._denominator += 1
+
+
+class TCMExamEM(TaskBasedParamEM):
+    """
+    The examination parameter of the TCM model
+    """
+    def _update(self, search_session, rank, session_params, history, last_session):
+        doc = search_session.web_results[rank]
+
+        attr = session_params[rank][TCM.param_names.attr].value()
+        exam = session_params[rank][TCM.param_names.exam].value()
+        fresh = session_params[0][TCM.param_names.fresh].value() \
+                if (doc.id in history) else 1.0
+        match = session_params[0][TCM.param_names.match].value()
+
+        if doc.click:
+            self._numerator += 1
+        else:
+            self._numerator += ((1 - attr) * exam * fresh * match /
+                                (1 - exam * attr * fresh * match))
+
+        self._denominator += 1
+
+
+class TCMMatchEM(TaskBasedParamEM):
+    """
+    Parameter controlling if the query matches user task or not.
+    """
+    @staticmethod
+    def get_no_clicks_given_match_prob(search_session, session_params, history):
+        """Compute probability of not having clicks in the session given the task match."""
+        fresh_param = session_params[0][TCM.param_names.fresh].value()
+        no_clicks_prob = 1.0
+        for rank, d in enumerate(search_session.web_results):
+            attr = session_params[rank][TCM.param_names.attr].value()
+            exam = session_params[rank][TCM.param_names.exam].value()
+            fresh = fresh_param if (d.id in history) else 1.0
+
+            no_clicks_prob *= (1 - attr * exam * fresh)
+        return no_clicks_prob
+
+    @staticmethod
+    def get_match_given_session_prob(search_session, session_params, history, last_session):
+        if any(d.click for d in search_session.web_results) or last_session:
+            return 1.0
+        else:
+            match = session_params[0][TCM.param_names.match].value()
+            new = session_params[0][TCM.param_names.new].value()
+            p = TCMMatchEM.get_no_clicks_given_match_prob(search_session, session_params,
+                                                          history)
+            # Here we simplify the computation assuming that next sessions' clicks
+            # do not depend on the current session given the value of N parameter.
+            return 1.0 / (1 + (1.0 / match - 1) / (p * new))
+
+
+    def _update(self, search_session, rank, session_params, history, last_session):
+        self._numerator += self.get_match_given_session_prob(search_session, session_params,
+                                                             history, last_session)
+        self._denominator += 1
+
+
+class TCMNewEM(TaskBasedParamEM):
+    """Parameter controlling if there should be further sessions"""
+    def _update(self, search_session, rank, session_params, history, last_session):
+        match_prob = TCMMatchEM.get_match_given_session_prob(search_session,
+                                                             session_params,
+                                                             history, last_session)
+        if last_session:
+            self._numerator += 0
+        else:
+            self._numerator += match_prob
+
+        self._denominator += match_prob
+
+
+class TCMFreshEM(TaskBasedParamEM):
+    def _update(self, search_session, rank, session_params, history, last_session):
+        doc = search_session.web_results[rank]
+        if doc.id in history:
+            attr = session_params[rank][TCM.param_names.attr].value()
+            exam = session_params[rank][TCM.param_names.exam].value()
+            fresh = session_params[0][TCM.param_names.fresh].value()
+            match = session_params[0][TCM.param_names.match].value()
+
+            if doc.click:
+                self._numerator += 1
+            else:
+                self._numerator += ((1 - fresh) * exam * attr * match /
+                                    (1 - exam * attr * fresh * match))
+
+            self._denominator += 1

--- a/pyclick/search_session/SearchSession.py
+++ b/pyclick/search_session/SearchSession.py
@@ -17,9 +17,10 @@ class SearchSession(object):
     and a list of corresponding web documents shown on a SERP.
     """
 
-    def __init__(self, query):
+    def __init__(self, query, task_id):
         self.query = query
         self.web_results = []
+        self.task_id = task_id
 
     def get_clicks(self):
         """

--- a/pyclick/utils/Utils.py
+++ b/pyclick/utils/Utils.py
@@ -6,6 +6,7 @@
 
 __author__ = 'Ilya Markov'
 
+from collections import Counter
 
 class Utils:
     """
@@ -41,3 +42,12 @@ class Utils:
             if search_session.query in queries:
                 search_sessions_filtered.append(search_session)
         return search_sessions_filtered
+
+    @staticmethod
+    def count_repeated_urls(search_sessions):
+        """Count URLs that appear more than once in the same **user** session (aka task)."""
+        c = Counter()
+        for s in search_sessions:
+            for d in s.web_results:
+                c[(s.task_id, d.id)] += 1
+        return c

--- a/pyclick/utils/YandexRelPredChallengeParser.py
+++ b/pyclick/utils/YandexRelPredChallengeParser.py
@@ -45,10 +45,10 @@ class YandexRelPredChallengeParser:
 
             # If the entry has 6 or more elements it is a query
             if len(entry_array) >= 6 and entry_array[2] == "Q":
-                session_id = entry_array[0]
+                task_id = entry_array[0]
                 query = entry_array[3]
                 results = entry_array[5:]
-                session = SearchSession(query)
+                session = SearchSession(query, task_id)
 
                 for result in results:
                     result = SearchResult(result, 0)
@@ -58,7 +58,7 @@ class YandexRelPredChallengeParser:
 
             # If the entry has 4 elements it is a click
             elif len(entry_array) == 4 and entry_array[2] == "C":
-                if entry_array[0] == session_id:
+                if entry_array[0] == task_id:
                     clicked_result = entry_array[3]
                     if clicked_result in results:
                         index = results.index(clicked_result)


### PR DESCRIPTION
TCM simplification:

In the original model only the documents previously **examined** by the user considered historical (variable H equals 1) whereas in my implementation all the documents **shown** are considered historical. It saves me from having to compute the sum (27) (see original paper "User-click modeling for understanding and predicting search-behavior").
